### PR TITLE
Yaml stdin support

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 // Config stores the configuration from cli flags and environment variables.
 type appConfig struct {
 	TemplateFile string
-	JSONDataFile string
+	DataFile     string
 	UseHTML      bool
 }
 
@@ -24,11 +24,11 @@ func main() {
 	kingpin.Version(version)
 
 	kingpin.
-		Flag("json-data", "A JSON file to use via the {{json.<foo>}} interface (Env: TEMPLE_JSON_DATA_FILE)").
-		Short('j').
-		PlaceHolder("JSON-FILE").
-		OverrideDefaultFromEnvar("TEMPLE_JSON_DATA_FILE").
-		ExistingFileVar(&config.JSONDataFile)
+		Flag("data", "A YAML or JSON file to use via the {{data.<foo>}} interface (Env: TEMPLE_DATA_FILE)").
+		Short('d').
+		PlaceHolder("DATA-FILE").
+		OverrideDefaultFromEnvar("TEMPLE_DATA_FILE").
+		ExistingFileVar(&config.DataFile)
 
 	kingpin.
 		Flag("html", "Use HTML templating instead of text templating (Env: TEMPLE_HTML)").
@@ -49,7 +49,7 @@ func main() {
 
 	kingpin.Parse()
 
-	funcMap := buildFuncMap(config.JSONDataFile)
+	funcMap := buildFuncMap(config.DataFile)
 	if config.UseHTML {
 		doHTMLTemplate(config.TemplateFile, funcMap, os.Stdout)
 	} else {


### PR DESCRIPTION
Made a couple changes. They are technically backwards incompatible (for example, json to yaml keeps type information and parameter change) so I can understand not wanting them in this form but it is a rather simple PR so consider it more for inspiration?

- defaults to stdin if filename is empty
- switched parser to a yaml parser instead of json
- changed the parameters + env vars to match the more general parser change
I did not update your testing script or add any tests (running on windows and haven't taken the time to do it).